### PR TITLE
Fix goodbye - Pilot survey

### DIFF
--- a/2025-08-15_debug/test_with_user_input.py
+++ b/2025-08-15_debug/test_with_user_input.py
@@ -13,7 +13,6 @@ headers = {"Authorization": f"Bearer {API_KEY}", "Content-Type": "application/js
 
 def get_system_prompt(pid, treatment, topic, group):
     stance = "agree" if treatment.split("_")[1] == "agree" else "disagree"
-    disagree_blurb = "Even if you don't agree with their viewpoint, try to engage the partner, looking for common ground and ways to work together."
 
     disagree_blurb = (
         "People often assume that in-group members share similar views, while out-group members hold more extreme and opposing positions."

--- a/summary_block.js
+++ b/summary_block.js
@@ -4,7 +4,74 @@ Qualtrics.SurveyEngine.addOnReady(function() {
     // Track errors for summary block
     var summaryErrorLog = []; // [{timestamp, errorType, errorMessage, context}]
     
-    // Helper function to log summary block errors
+    // Key rotation management
+    var currentKeyIndex = 0; // Track which key we're currently using
+    var availableKeys = []; // Will store all available API keys
+    var usedKeys = new Set(); // Track which keys have been used in this session
+    var totalRetryCount = 0; // Track total retries across all attempts
+    
+    // Initialize available keys
+    function initializeKeys() {
+        var primaryKey = Qualtrics.SurveyEngine.getEmbeddedData('OpenRouterAPIKey') || "sk-or...";
+        var otherKeys = [];
+        for (var i = 1; i <= 2; i++) {
+            var key = Qualtrics.SurveyEngine.getEmbeddedData('OpenRouterAPIKey' + i);
+            if (key) {
+                otherKeys.push(key);
+            }
+        }
+        availableKeys=otherKeys
+        // availableKeys = [primaryKey, ...otherKeys].filter(key => key && key !== "sk-or...");
+        console.log("Initialized with", availableKeys.length, "API keys");
+        console.log("Available keys:", availableKeys);
+    }
+    
+    // Get next available key
+    function getNextKey() {
+        if (availableKeys.length === 0) {
+            initializeKeys();
+        }
+        
+        // Find next unused key
+        for (var i = 0; i < availableKeys.length; i++) {
+            var keyIndex = (currentKeyIndex + i) % availableKeys.length;
+            var key = availableKeys[keyIndex];
+            if (!usedKeys.has(key)) {
+                currentKeyIndex = keyIndex;
+                usedKeys.add(key);
+                console.log("Using API key at index", keyIndex);
+                return key;
+            }
+        }
+        
+        // If all keys used, reset and use first key
+        console.log("All keys used, resetting to first key");
+        usedKeys.clear();
+        currentKeyIndex = 0;
+        usedKeys.add(availableKeys[0]);
+        return availableKeys[0];
+    }
+    
+    // Mark current key as failed and get next key
+    function rotateToNextKey() {
+        if (availableKeys.length > 1) {
+            currentKeyIndex = (currentKeyIndex + 1) % availableKeys.length;
+            console.log("Rotated to key index", currentKeyIndex);
+        }
+    }
+    
+    // Show exhaustion message and enable Next button
+    function showExhaustionMessage() {
+        document.getElementById('apiStatus').innerText = 
+            "We are facing some trouble with the chatbot right now. Please click Next and retry again in a few minutes. If the problem persists, please contact us at gciampag+chat@umd.edu. Thank you for the patience!";
+        document.getElementById('apiStatus').style.color = "red";
+        jQuery("#NextButton").show();
+
+        Qualtrics.SurveyEngine.setEmbeddedData('summary_passed', "false");
+        console.log("Variable `summary_passed`: ", Qualtrics.SurveyEngine.getEmbeddedData('summary_passed'));
+    }
+
+    // Helper function to log summary block errorss
     function logSummaryError(errorType, errorMessage, context = {}) {
         var errorEntry = {
             timestamp: Date.now(),
@@ -23,8 +90,8 @@ Qualtrics.SurveyEngine.addOnReady(function() {
         console.error(`[SUMMARY-${errorType}]:`, errorMessage, context);
     }
 
-    function sendChatToOpenRouter(instructions, onSuccess, onError) {
-        var apiKey = Qualtrics.SurveyEngine.getEmbeddedData('OpenRouterAPIKey') || "sk-or-...";
+    function sendChatToOpenRouter(instructions, onSuccess, onError, retryCount = 0) {
+        var apiKey = getNextKey();
         var OR_model = Qualtrics.SurveyEngine.getEmbeddedData('setModel') || "openai/gpt-4.1";
 
         var payload = {
@@ -35,7 +102,7 @@ Qualtrics.SurveyEngine.addOnReady(function() {
             "stream": false
         };
 
-        console.log("Sending to OpenRouter:", payload);
+        console.log("Sending to OpenRouter with key index", currentKeyIndex, "retry count:", retryCount, "total retries:", totalRetryCount, ":", payload);
 
         var xhr = new XMLHttpRequest();
         xhr.open("POST", "https://openrouter.ai/api/v1/chat/completions", true);
@@ -45,17 +112,27 @@ Qualtrics.SurveyEngine.addOnReady(function() {
         // Record request timestamp for timeout tracking
         var requestSentTime = Date.now();
         
-        // Set up timeout (2 minutes)
+        // Set up timeout (1.5 minutes)
         var timeoutId = setTimeout(function() {
-            logSummaryError("API_TIMEOUT", "Summary generation timed out after 2 minutes", {
-                timeoutThreshold: 120000,
+            logSummaryError("API_TIMEOUT", "Summary generation timed out after 1.5 minutes", {
+                timeoutThreshold: 90000,
                 requestSentTime: requestSentTime,
                 elapsedTime: Date.now() - requestSentTime,
-                instructionsLength: instructions.length
+                instructionsLength: instructions.length,
+                retryCount: retryCount,
+                currentKeyIndex: currentKeyIndex
             });
             xhr.abort();
-            onError("Request timed out");
-        }, 120000);
+            
+            // Try with next key if we haven't reached max retries (2)
+            if (retryCount < 2) {
+                console.log("Timeout occurred, trying with next API key...");
+                rotateToNextKey();
+                sendChatToOpenRouter(instructions, onSuccess, onError, retryCount + 1);
+            } else {
+                onError("Request timed out after 2 retries");
+            }
+        }, 90000);
 
         xhr.onreadystatechange = function() {
             if (xhr.readyState === 4) {
@@ -78,9 +155,19 @@ Qualtrics.SurveyEngine.addOnReady(function() {
                         status: xhr.status,
                         statusText: xhr.statusText,
                         responseText: xhr.responseText,
-                        instructionsLength: instructions.length
+                        instructionsLength: instructions.length,
+                        retryCount: retryCount,
+                        currentKeyIndex: currentKeyIndex
                     });
-                    onError("Error: HTTP " + xhr.status);
+                    
+                    // Try with next key for certain HTTP errors
+                    if ((xhr.status === 401 || xhr.status === 403 || xhr.status >= 500) && retryCount < 2) {
+                        console.log("HTTP error occurred, trying with next API key...");
+                        rotateToNextKey();
+                        sendChatToOpenRouter(instructions, onSuccess, onError, retryCount + 1);
+                    } else {
+                        onError("Error: HTTP " + xhr.status);
+                    }
                 }
             }
         };
@@ -89,9 +176,19 @@ Qualtrics.SurveyEngine.addOnReady(function() {
             clearTimeout(timeoutId);
             logSummaryError("NETWORK_ERROR", "Network error during summary generation", {
                 readyState: xhr.readyState,
-                instructionsLength: instructions.length
+                instructionsLength: instructions.length,
+                retryCount: retryCount,
+                currentKeyIndex: currentKeyIndex
             });
-            onError("Network error");
+            
+            // Try with next key for network errors
+            if (retryCount < 2) {
+                console.log("Network error occurred, trying with next API key...");
+                rotateToNextKey();
+                sendChatToOpenRouter(instructions, onSuccess, onError, retryCount + 1);
+            } else {
+                onError("Network error after 2 retries");
+            }
         };
 
         xhr.send(JSON.stringify(payload));
@@ -107,6 +204,21 @@ Qualtrics.SurveyEngine.addOnReady(function() {
             document.getElementById('apiStatus').style.color = "blue";
             return;
         }
+        
+        // Check if we've exceeded max retries
+        if (totalRetryCount >= 2) {
+            showExhaustionMessage();
+            return;
+        }
+        
+        // Rotate to next key on retry (when user clicks submit again after error)
+        if (document.getElementById('apiStatus').innerText.includes("Error") || 
+            document.getElementById('apiStatus').innerText.includes("Please click the submit button again")) {
+            console.log("Retry detected, rotating to next API key...");
+            totalRetryCount++;
+            rotateToNextKey();
+        }
+        
         Qualtrics.SurveyEngine.setEmbeddedData('initial_opinion', userPrompt);
 
         document.getElementById('apiStatus').innerText = "Generating summary... Please wait.";
@@ -151,10 +263,10 @@ Qualtrics.SurveyEngine.addOnReady(function() {
                     logSummaryError("RESPONSE_PARSE_ERROR", "Error parsing summary response: " + parseError.message, {
                         response: response.substring(0, 200) + (response.length > 200 ? "..." : ""),
                         instructionsLength: instructions.length,
-                        userPrompt: userPrompt.substring(0, 100) + (userPrompt.length > 100 ? "..." : "")
+                        userPrompt: userPrompt.substring(0, 100) + (userPrompt.length > 100 ? "..." : ""),
+                        currentKeyIndex: currentKeyIndex
                     });
-                    document.getElementById('apiStatus').innerText = "Error processing summary. Please try again.";
-                    jQuery("#NextButton").show();
+                    showExhaustionMessage();
                 }
             },
             function(error) {
@@ -163,11 +275,11 @@ Qualtrics.SurveyEngine.addOnReady(function() {
                     model: Qualtrics.SurveyEngine.getEmbeddedData('setModel') || "default",
                     instructions: instructions,
                     userPrompt: userPrompt.substring(0, 100) + (userPrompt.length > 100 ? "..." : ""),
-                    topic: topic
+                    topic: topic,
+                    currentKeyIndex: currentKeyIndex
                 });
                 console.error(error);
-                document.getElementById('apiStatus').innerText = "Error generating summary. Please try again.";
-                jQuery("#NextButton").show();
+                showExhaustionMessage();
             }
         );
     });


### PR DESCRIPTION
Error handling in summary & treatment block
- Timeouts are set to be 1.5 mins for a request. There are 4 API available keys.
- When an error occurs (timeout or parsing error), we replace the current key with the next unused key, keeping track of the replacement key index so we can cycle through the keys if other errors happen.
- The max number of retries on all errors is set to be 2. When absolutely everything fails (i.e., 2 retries are reached or when all keys are exhausted), (although this is very rare), we show the next button along with an error message & end the survey with an option to retake.